### PR TITLE
Performance Improvements

### DIFF
--- a/pipelines.go
+++ b/pipelines.go
@@ -5,9 +5,11 @@ import (
 	"sync"
 )
 
+const buffer int = 64
+
 // GenerateStream takes a function that generates data and returns a channel of type T
 func GenerateStream[T any](ctx context.Context, fn func(context.Context) T) <-chan T {
-	stream := make(chan T)
+	stream := make(chan T, buffer)
 
 	go func() {
 		defer close(stream)
@@ -26,7 +28,7 @@ func GenerateStream[T any](ctx context.Context, fn func(context.Context) T) <-ch
 
 // StreamSlice takes a slice of type []T and returns a channel of type T
 func StreamSlice[T any](ctx context.Context, data []T) <-chan T {
-	stream := make(chan T)
+	stream := make(chan T, buffer)
 
 	go func() {
 		defer close(stream)
@@ -45,7 +47,7 @@ func StreamSlice[T any](ctx context.Context, data []T) <-chan T {
 
 // StreamMap takes a map of type map[T]H and returns a channel of type H
 func StreamMap[T comparable, H comparable](ctx context.Context, data map[T]H) <-chan H {
-	stream := make(chan H)
+	stream := make(chan H, buffer)
 
 	go func() {
 		defer close(stream)
@@ -65,7 +67,7 @@ func StreamMap[T comparable, H comparable](ctx context.Context, data map[T]H) <-
 // FanOut controls concurrent processing of data from the input channel
 func FanOut[T any, H any](ctx context.Context, inputStream <-chan T, fn func(context.Context, T) H, numFan int) []<-chan H {
 	process := func() <-chan H {
-		stream := make(chan H)
+		stream := make(chan H, buffer)
 
 		go func() {
 			defer close(stream)
@@ -96,7 +98,7 @@ func FanOut[T any, H any](ctx context.Context, inputStream <-chan T, fn func(con
 // FanIn takes any number of readonly channels and returns a fanned in channel
 func FanIn[T any](ctx context.Context, channels ...<-chan T) <-chan T {
 	var wg sync.WaitGroup
-	fannedInStream := make(chan T)
+	fannedInStream := make(chan T, 1)
 
 	transfer := func(c <-chan T) {
 		defer wg.Done()

--- a/pipelines.go
+++ b/pipelines.go
@@ -5,11 +5,11 @@ import (
 	"sync"
 )
 
-const buffer int = 64
+const Buffer int = 64
 
 // GenerateStream takes a function that generates data and returns a channel of type T
 func GenerateStream[T any](ctx context.Context, fn func(context.Context) T) <-chan T {
-	stream := make(chan T, buffer)
+	stream := make(chan T, Buffer)
 
 	go func() {
 		defer close(stream)
@@ -28,7 +28,7 @@ func GenerateStream[T any](ctx context.Context, fn func(context.Context) T) <-ch
 
 // StreamSlice takes a slice of type []T and returns a channel of type T
 func StreamSlice[T any](ctx context.Context, data []T) <-chan T {
-	stream := make(chan T, buffer)
+	stream := make(chan T, Buffer)
 
 	go func() {
 		defer close(stream)
@@ -47,7 +47,7 @@ func StreamSlice[T any](ctx context.Context, data []T) <-chan T {
 
 // StreamMap takes a map of type map[T]H and returns a channel of type H
 func StreamMap[T comparable, H comparable](ctx context.Context, data map[T]H) <-chan H {
-	stream := make(chan H, buffer)
+	stream := make(chan H, Buffer)
 
 	go func() {
 		defer close(stream)
@@ -67,7 +67,7 @@ func StreamMap[T comparable, H comparable](ctx context.Context, data map[T]H) <-
 // FanOut controls concurrent processing of data from the input channel
 func FanOut[T any, H any](ctx context.Context, inputStream <-chan T, fn func(context.Context, T) H, numFan int) []<-chan H {
 	process := func() <-chan H {
-		stream := make(chan H, buffer)
+		stream := make(chan H, Buffer)
 
 		go func() {
 			defer close(stream)
@@ -99,6 +99,36 @@ func FanOut[T any, H any](ctx context.Context, inputStream <-chan T, fn func(con
 func FanIn[T any](ctx context.Context, channels ...<-chan T) <-chan T {
 	var wg sync.WaitGroup
 	fannedInStream := make(chan T, 1)
+
+	transfer := func(c <-chan T) {
+		defer wg.Done()
+
+		for msg := range c {
+			select {
+			case <-ctx.Done():
+				return
+			case fannedInStream <- msg:
+			}
+		}
+	}
+
+	for i := range channels {
+		wg.Add(1)
+		go transfer(channels[i])
+	}
+
+	go func() {
+		wg.Wait()
+		close(fannedInStream)
+	}()
+
+	return fannedInStream
+}
+
+// FanInBuffer takes any number of readonly channels and a buffer value to return a fanned in channel
+func FanInBuffer[T any](ctx context.Context, buffer int, channels ...<-chan T) <-chan T {
+	var wg sync.WaitGroup
+	fannedInStream := make(chan T, buffer)
 
 	transfer := func(c <-chan T) {
 		defer wg.Done()

--- a/pipelines.go
+++ b/pipelines.go
@@ -98,7 +98,7 @@ func FanOut[T any, H any](ctx context.Context, inputStream <-chan T, fn func(con
 // FanIn takes any number of readonly channels and returns a fanned in channel
 func FanIn[T any](ctx context.Context, channels ...<-chan T) <-chan T {
 	var wg sync.WaitGroup
-	fannedInStream := make(chan T, 1)
+	fannedInStream := make(chan T, len(channels))
 
 	transfer := func(c <-chan T) {
 		defer wg.Done()

--- a/pipelines_bench_test.go
+++ b/pipelines_bench_test.go
@@ -1,0 +1,186 @@
+package pipelines
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// benchSizes is the set of input lengths each benchmark sweeps over.
+var benchSizes = []int{100, 1_000, 10_000}
+
+// benchFans is the set of fan-out widths the FanOut/FanIn benchmarks sweep over.
+var benchFans = []int{1, 4, 8, 16}
+
+// benchID is the no-op process function used by the fan benchmarks. It
+// isolates pipeline/channel overhead from any user workload.
+func benchID(ctx context.Context, x int) int { return x }
+
+func makeSlice(n int) []int {
+	data := make([]int, n)
+
+	for i := range data {
+		data[i] = TestInt
+	}
+
+	return data
+}
+
+func makeMap(n int) map[int]int {
+	data := make(map[int]int, n)
+
+	for i := 0; i < n; i++ {
+		data[i] = TestInt
+	}
+
+	return data
+}
+
+func BenchmarkGenerateStream(b *testing.B) {
+	gen := func(ctx context.Context) int { return TestInt }
+
+	for i := range benchSizes {
+		b.Run(fmt.Sprintf("size=%d", benchSizes[i]), func(b *testing.B) {
+			b.ReportAllocs()
+
+			for b.Loop() {
+				ctx, cancel := context.WithCancel(context.Background())
+
+				stream := GenerateStream(ctx, gen)
+
+				for range benchSizes[i] {
+					<-stream
+				}
+
+				cancel()
+			}
+		})
+	}
+}
+
+func BenchmarkStreamSlice(b *testing.B) {
+	for i := range benchSizes {
+		data := makeSlice(benchSizes[i])
+
+		b.Run(fmt.Sprintf("size=%d", benchSizes[i]), func(b *testing.B) {
+			b.ReportAllocs()
+
+			for b.Loop() {
+				ctx, cancel := context.WithCancel(context.Background())
+
+				for range StreamSlice(ctx, data) {
+				}
+
+				cancel()
+			}
+		})
+	}
+}
+
+func BenchmarkStreamMap(b *testing.B) {
+	for i := range benchSizes {
+		data := makeMap(benchSizes[i])
+
+		b.Run(fmt.Sprintf("size=%d", benchSizes[i]), func(b *testing.B) {
+			b.ReportAllocs()
+
+			for b.Loop() {
+				ctx, cancel := context.WithCancel(context.Background())
+
+				for range StreamMap(ctx, data) {
+				}
+
+				cancel()
+			}
+		})
+	}
+}
+
+func BenchmarkFanOut(b *testing.B) {
+	for i := range benchSizes {
+		data := makeSlice(benchSizes[i])
+
+		b.Run(fmt.Sprintf("size=%d", benchSizes[i]), func(b *testing.B) {
+			for _, fan := range benchFans {
+				b.Run(fmt.Sprintf("fan=%d", fan), func(b *testing.B) {
+					b.ReportAllocs()
+
+					for b.Loop() {
+						ctx, cancel := context.WithCancel(context.Background())
+
+						stream := StreamSlice(ctx, data)
+						channels := FanOut(ctx, stream, benchID, fan)
+
+						// drain every fan channel so producers complete each iteration
+						var wg sync.WaitGroup
+						for i := range channels {
+							wg.Add(1)
+							go func(c <-chan int) {
+								defer wg.Done()
+								for range c {
+								}
+							}(channels[i])
+						}
+
+						wg.Wait()
+						cancel()
+					}
+				})
+			}
+		})
+	}
+}
+
+func BenchmarkFanIn(b *testing.B) {
+	for _, n := range benchSizes {
+		data := makeSlice(n)
+
+		b.Run(fmt.Sprintf("size=%d", n), func(b *testing.B) {
+			for _, fan := range benchFans {
+				b.Run(fmt.Sprintf("fan=%d", fan), func(b *testing.B) {
+					b.ReportAllocs()
+
+					for b.Loop() {
+						ctx, cancel := context.WithCancel(context.Background())
+
+						stream := StreamSlice(ctx, data)
+						fanOut := FanOut(ctx, stream, benchID, fan)
+
+						for range FanIn(ctx, fanOut...) {
+						}
+
+						cancel()
+					}
+				})
+			}
+		})
+	}
+}
+
+func BenchmarkPipeline(b *testing.B) {
+	for i := range benchSizes {
+		data := makeSlice(benchSizes[i])
+
+		b.Run(fmt.Sprintf("size=%d", benchSizes[i]), func(b *testing.B) {
+			for _, fan := range benchFans {
+				b.Run(fmt.Sprintf("fan=%d", fan), func(b *testing.B) {
+					b.ReportAllocs()
+
+					for b.Loop() {
+						ctx, cancel := context.WithCancel(context.Background())
+
+						stream := StreamSlice(ctx, data)
+						fanOut := FanOut(ctx, stream, benchID, fan)
+						merged := FanIn(ctx, fanOut...)
+
+						for range merged {
+						}
+
+						cancel()
+					}
+				})
+			}
+		})
+	}
+}

--- a/pipelines_bench_test.go
+++ b/pipelines_bench_test.go
@@ -7,15 +7,15 @@ import (
 	"testing"
 )
 
-// benchSizes is the set of input lengths each benchmark sweeps over.
 var benchSizes = []int{100, 1_000, 10_000}
 
-// benchFans is the set of fan-out widths the FanOut/FanIn benchmarks sweep over.
 var benchFans = []int{1, 4, 8, 16}
 
-// benchID is the no-op process function used by the fan benchmarks. It
-// isolates pipeline/channel overhead from any user workload.
-func benchID(ctx context.Context, x int) int { return x }
+var benchBuffers = []int{1, 64, 256}
+
+func benchID(ctx context.Context, x int) int {
+	return x
+}
 
 func makeSlice(n int) []int {
 	data := make([]int, n)
@@ -133,10 +133,10 @@ func BenchmarkFanOut(b *testing.B) {
 }
 
 func BenchmarkFanIn(b *testing.B) {
-	for _, n := range benchSizes {
-		data := makeSlice(n)
+	for i := range benchSizes {
+		data := makeSlice(benchSizes[i])
 
-		b.Run(fmt.Sprintf("size=%d", n), func(b *testing.B) {
+		b.Run(fmt.Sprintf("size=%d", benchSizes[i]), func(b *testing.B) {
 			for _, fan := range benchFans {
 				b.Run(fmt.Sprintf("fan=%d", fan), func(b *testing.B) {
 					b.ReportAllocs()
@@ -178,6 +178,37 @@ func BenchmarkPipeline(b *testing.B) {
 						}
 
 						cancel()
+					}
+				})
+			}
+		})
+	}
+}
+
+func BenchmarkPipelineBuffer(b *testing.B) {
+	for i := range benchSizes {
+		data := makeSlice(benchSizes[i])
+
+		b.Run(fmt.Sprintf("size=%d", benchSizes[i]), func(b *testing.B) {
+			for _, fan := range benchFans {
+				b.Run(fmt.Sprintf("fan=%d", fan), func(b *testing.B) {
+					for n := range benchBuffers {
+						b.Run(fmt.Sprintf("buf=%d", benchBuffers[n]), func(b *testing.B) {
+							b.ReportAllocs()
+
+							for b.Loop() {
+								ctx, cancel := context.WithCancel(context.Background())
+
+								stream := StreamSlice(ctx, data)
+								fanOut := FanOut(ctx, stream, benchID, fan)
+								merged := FanInBuffer(ctx, benchBuffers[n], fanOut...)
+
+								for range merged {
+								}
+
+								cancel()
+							}
+						})
 					}
 				})
 			}


### PR DESCRIPTION
# What's Changed

Improve performance by utilizing buffered channels, removing the cost of synchronous hand-offs

## Benchmark Results

Buffered medians vs. the unbuffered baseline above. Percentages are change in ns/op
(negative = faster).

### StreamSlice

| size | unbuffered | buf=1 | buf=64 | buf=256 |
| ---: | ---: | ---: | ---: | ---: |
| 100 | 20.98 µs | 16.34 µs (−22%) | 9.14 µs (−56%) | 9.79 µs (−53%) |
| 1,000 | 205.2 µs | 156.5 µs (−24%) | 80.5 µs (−61%) | 78.8 µs (−62%) |
| 10,000 | 2.018 ms | 1.525 ms (−24%) | 792 µs (−61%) | 777 µs (−62%) |

### StreamMap

| size | unbuffered | buf=1 | buf=64 | buf=256 |
| ---: | ---: | ---: | ---: | ---: |
| 100 | 22.18 µs | 16.84 µs (−24%) | 9.90 µs (−55%) | 10.56 µs (−52%) |
| 1,000 | 214.9 µs | 161.7 µs (−25%) | 91.3 µs (−57%) | 90.2 µs (−58%) |
| 10,000 | 2.126 ms | 1.597 ms (−25%) | 875 µs (−59%) | 889 µs (−58%) |

### Pipeline (StreamSlice → FanOut → FanIn)

|   size | fan | unbuffered |           buf=1 |          buf=64 |         buf=256 |
| -----: | --: | ---------: | --------------: | --------------: | --------------: |
|    100 |   1 |   87.65 µs |  64.6 µs (−26%) |  30.6 µs (−65%) |  27.1 µs (−69%) |
|    100 |   4 |   140.5 µs | 103.0 µs (−27%) |  47.1 µs (−67%) |  48.0 µs (−66%) |
|    100 |   8 |   209.4 µs | 150.1 µs (−28%) |  59.6 µs (−72%) |  57.3 µs (−73%) |
|    100 |  16 |   245.8 µs | 195.9 µs (−20%) |  71.1 µs (−71%) |  62.3 µs (−75%) |
|  1,000 |   1 |   868.7 µs | 615.7 µs (−29%) |   301 µs (−65%) |   273 µs (−69%) |
|  1,000 |   4 |   1.464 ms | 1.027 ms (−30%) |   442 µs (−70%) |   380 µs (−74%) |
|  1,000 |   8 |   2.026 ms | 1.611 ms (−20%) |   521 µs (−74%) |   417 µs (−79%) |
|  1,000 |  16 |   2.317 ms | 1.914 ms (−17%) |   580 µs (−75%) |   454 µs (−80%) |
| 10,000 |   1 |   8.663 ms | 6.224 ms (−28%) | 2.974 ms (−66%) | 2.947 ms (−66%) |
| 10,000 |   4 |   13.53 ms | 10.40 ms (−23%) | 4.572 ms (−66%) | 3.676 ms (−73%) |
| 10,000 |   8 |   21.70 ms | 16.66 ms (−23%) | 5.056 ms (−77%) | 3.775 ms (−83%) |
| 10,000 |  16 |   21.99 ms | 18.55 ms (−16%) | 5.120 ms (−77%) | 3.787 ms (−83%) |

### Memory cost of buffering

`allocs/op` is **independent of buffer capacity** (a buffered channel is still one
allocation): 6 for source streams, 13–60 for the pipeline. Only `B/op` grows, since the
buffer reserves slots up front:

| Benchmark                |    buf=1 |    buf=64 |   buf=256 |
| ------------------------ | -------: | --------: | --------: |
| StreamSlice (any size)   |    408 B |     920 B |  2.52 KiB |
| StreamMap (any size)     |    392 B |     904 B |  2.51 KiB |
| Pipeline size=100 fan=16 | 4.14 KiB | 13.15 KiB | 42.41 KiB |